### PR TITLE
Review Updates - 18 Sept

### DIFF
--- a/_about/Milestones.md
+++ b/_about/Milestones.md
@@ -16,10 +16,9 @@ variant: tiptap
 <p><strong>May 2024</strong> - Technical Committee's Approval (Completed)</p>
 </li>
 <li>
-<p><strong>June to August 2024</strong> - The public consultation for Singapore
-Standard on Management for OAE Activities is open from 14 June to 15 August
-2024. Click <a href="/files/Step_by_Step_guide_to_provide_comments_to_SS.pdf" rel="noopener noreferrer nofollow" target="_blank">here </a>for
-a step-by-step guide on providing comments.</p>
+<p><strong>June to August 2024</strong> - The public consultation for the
+Singapore Standard on Management for OAE Activities concluded on 15 August
+2024. (Completed)</p>
 </li>
 <li>
 <p><strong>Target October 2024</strong> - Standards Committee's Approval</p>

--- a/_about/OAE in Singapore/OAE Professionals.md
+++ b/_about/OAE in Singapore/OAE Professionals.md
@@ -19,9 +19,6 @@ learning outcomes that promote personal growth and skill development.</p>
 </div>
 <h4><strong>Outdoor Adventure Educator (MOE)</strong></h4>
 <div class="iframe-wrapper">
-<iframe height="315" width="560" allowfullscreen="true" frameborder="0" src="https://www.youtube.com/embed/o8CbIYTEob8?si=hg28QwIibB4LMk7V"></iframe>
-</div>
-<div class="iframe-wrapper">
 <iframe height="315" width="560" allowfullscreen="true" frameborder="0" src="https://www.youtube.com/embed/fqQiyM06qM4?si=_gh2bJdUASrcsQtm"></iframe>
 </div>
 <h4><strong>Outward Bound Singapore Instructor (OBS)</strong></h4>

--- a/_about/OAE in Singapore/OAE Professionals.md
+++ b/_about/OAE in Singapore/OAE Professionals.md
@@ -21,6 +21,9 @@ learning outcomes that promote personal growth and skill development.</p>
 <div class="iframe-wrapper">
 <iframe height="315" width="560" allowfullscreen="true" frameborder="0" src="https://www.youtube.com/embed/o8CbIYTEob8?si=hg28QwIibB4LMk7V"></iframe>
 </div>
+<div class="iframe-wrapper">
+<iframe height="315" width="560" allowfullscreen="true" frameborder="0" src="https://www.youtube.com/embed/fqQiyM06qM4?si=_gh2bJdUASrcsQtm"></iframe>
+</div>
 <h4><strong>Outward Bound Singapore Instructor (OBS)</strong></h4>
 <div class="iframe-wrapper">
 <iframe height="315" width="560" allowfullscreen="true" frameborder="0" src="https://www.youtube.com/embed/xOPlalbQ_UE?si=9QQa0BPC3zn2Oy_T"></iframe>

--- a/_media-room/Events & Engagements.md
+++ b/_media-room/Events & Engagements.md
@@ -5,6 +5,7 @@ description: ""
 variant: tiptap
 ---
 <h4>Upcoming</h4>
+<h4>Past</h4>
 <table style="minWidth: 50px">
 <colgroup>
 <col>
@@ -28,33 +29,6 @@ variant: tiptap
 <img style="width: 100%" height="auto" width="100%" alt="OAE Engagement Teaser 2" src="/images/OAE_Engagement_Teaser_2.jpg">
 </div>
 </td>
-</tr>
-<tr>
-<td rowspan="1" colspan="1">
-<p></p>
-</td>
-<td rowspan="1" colspan="1">
-<p>Event Registration Link</p>
-<p><a href="https://go.gov.sg/oaecouncilbeyondppe" rel="noopener noreferrer nofollow" target="_blank">https://go.gov.sg/oaecouncilbeyondppe</a>
-</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h4>Past</h4>
-<table style="minWidth: 50px">
-<colgroup>
-<col>
-<col>
-</colgroup>
-<tbody>
-<tr>
-<th rowspan="1" colspan="1">
-<p>Event</p>
-</th>
-<th rowspan="1" colspan="1">
-<p>Details</p>
-</th>
 </tr>
 <tr>
 <td rowspan="1" colspan="1">

--- a/_resources/Standards & Guidelines/Singapore Standard.md
+++ b/_resources/Standards & Guidelines/Singapore Standard.md
@@ -6,7 +6,7 @@ variant: tiptap
 third_nav_title: Standards & Guidelines
 ---
 <h3><strong>Information on Singapore Standard for OAE Activities (SS OAEA)</strong></h3>
-<p><em>[The public consultation for Singapore Standard on Management for OAE Activities is open from 14 June to 15 August 2024. Click <a href="/files/Step_by_Step_guide_to_provide_comments_to_SS.pdf" rel="noopener noreferrer nofollow" target="_blank">here </a>for a step-by-step guide on providing comments.]</em>
+<p><em>[The public consultation for the Singapore Standard on Management for OAE Activities concluded on 15 August 2024.]</em>
 </p>
 <p>The SS OAEA, owned by Enterprise Singapore (<a href="https://www.enterprisesg.gov.sg" rel="noopener noreferrer nofollow" target="_blank">ESG</a>), is co-convened by Outward
 Bound Singapore (<a href="https://www.nyc.gov.sg/en/obs" rel="noopener noreferrer nofollow" target="_blank">OBS</a>) and the Outdoor Learning

--- a/index.md
+++ b/index.md
@@ -32,12 +32,6 @@ sections:
       title: Announcements
       id: announcements
       announcement_items:
-        - title: OAE Practitioners Engagement Event
-          date: 29 August 2024
-          announcement: An event organised by the OAE Council for OAE practitioners.
-            Click   below for more details.
-          link_text: Register Now!
-          link_url: https://www.singaporeoae.sg/media-room/events/
         - title: OAE Council Professional Development Research Study
           date: 05 August 2024
           announcement: The Outdoor Adventure Education (OAE) Council is embarking on a

--- a/index.md
+++ b/index.md
@@ -5,8 +5,7 @@ description: An official site developed by the OAE Council Singapore to provide
   reliable resources and latest happenings in the OAE landscape.
 image: /images/sharper_logo.png
 permalink: /
-notification: The public consultation for Singapore Standard on Management for
-  OAE Activities is open from 14 June to 15 August 2024
+notification: The OAE Professional Development Research Study is currently ongoing.
 sections:
   - hero:
       title: Singapore OAE


### PR DESCRIPTION
1. Replace Notification Banner
Before:
The public consultation for Singapore Standard on Management for OAE Activities is open from 14 June to 15 August 2024
After:
The OAE Professional Development Research Study is currently ongoing.
2. Remove Engagement Event from Homepage/Annoucement
3. Moved Engagement Event from Upcoming to Past under Media Room/Events & Engagements
4. Replaced MOE Video under About/OAE Professionals
5. Edited Singapore Standards under Resources/Standards & Guidelines/Singapore Standards
Before:
The public consultation for Singapore Standard on Management for OAE Activities isopenfrom 14 June to 15 August 2024. Click <a href="/files/Step_by_Step_guide_to_provide_comments_to_SS.pdf" rel="noopener noreferrer nofollow" target="_blank">here </a>for a step-by-step guide on providing comments.
After:
The public consultation for the Singapore Standard on Management for OAE Activities concluded on 15 August 2024.